### PR TITLE
更改插槽标签为template

### DIFF
--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/button/index.vue
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/button/index.vue
@@ -8,9 +8,9 @@
         :class-prefix="iconClassPrefix"
         :font-class-name="iconFontClassName"
       ></nut-icon>
-      <view :class="{ text: icon || loading }" v-if="$slots.default">
+      <template :class="{ text: icon || loading }" v-if="$slots.default">
         <slot></slot>
-      </view>
+      </template>
     </view>
   </view>
 </template>


### PR DESCRIPTION
template不会有两边的空白，有些人喜欢点两边，所以兼容