### PR TITLE
底部导航栏与上方图标留间隙

### DIFF
--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/tabbaritem/index.scss
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/tabbaritem/index.scss
@@ -77,6 +77,7 @@
       font-size: $tabbar-item-text-font-size;
       line-height: $tabbar-item-text-line-height;
       display: block;
+      margin-top: 8rpx;
     }
     &_big-word {
       font-size: $font-size-large;


### PR DESCRIPTION
建议使用props适配