### PR TITLE
fix: 修复app,H5下navbar如果设置为fixed,高度塌陷问题,修复顶部安全区高度获取不正确问题

### DIFF
--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/navbar/index.scss
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/navbar/index.scss
@@ -28,7 +28,6 @@
   }
   &--fixed {
     position: fixed;
-    top: 0;
     left: 0;
     width: 100%;
   }
@@ -138,3 +137,4 @@
     }
   }
 }
+

--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/navbar/index.vue
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/navbar/index.vue
@@ -1,14 +1,26 @@
 <template>
-  <view v-if="fixed && placeholder" class="nut-navbar--placeholder" :style="{ height: navHeight + 'px' }">
-    <view :class="classes" :style="styles" ref="navBarHtml">
+  <view v-if="safeAreaInsetTop" :style="[statusBarStyle]"></view>
+  <view
+    v-if="fixed && placeholder"
+    class="nut-navbar--placeholder"
+    :style="{ height: navHeight + 'px' }"
+  >
+    <view :class="classes" :style="styles" id="navBarHtml">
       <view class="nut-navbar__left" @click="handleLeft">
         <nut-icon v-if="leftShow" color="#979797" name="left"></nut-icon>
         <view v-if="leftText" class="nut-navbar__text">{{ leftText }}</view>
         <slot name="left"></slot>
       </view>
       <view class="nut-navbar__title">
-        <view v-if="title" class="title" @click="handleCenter">{{ title }}</view>
-        <nut-icon v-if="titIcon" class="icon" :name="titIcon" @click="handleCenterIcon"></nut-icon>
+        <view v-if="title" class="title" @click="handleCenter">{{
+          title
+        }}</view>
+        <nut-icon
+          v-if="titIcon"
+          class="icon"
+          :name="titIcon"
+          @click="handleCenterIcon"
+        ></nut-icon>
         <slot name="content"></slot>
       </view>
       <view class="nut-navbar__right" @click="handleRight">
@@ -25,7 +37,12 @@
     </view>
     <view class="nut-navbar__title">
       <view v-if="title" class="title" @click="handleCenter">{{ title }}</view>
-      <nut-icon v-if="titIcon" class="icon" :name="titIcon" @click="handleCenterIcon"></nut-icon>
+      <nut-icon
+        v-if="titIcon"
+        class="icon"
+        :name="titIcon"
+        @click="handleCenterIcon"
+      ></nut-icon>
       <slot name="content"></slot>
     </view>
     <view class="nut-navbar__right" @click="handleRight">
@@ -36,9 +53,9 @@
 </template>
 
 <script lang="ts">
-import { onMounted, computed, toRefs, ref } from 'vue';
-import { createComponent } from '../../utils/create';
-const { componentName, create } = createComponent('navbar');
+import { onMounted, computed, toRefs, ref } from 'vue'
+import { createComponent } from '../../utils/create'
+const { componentName, create } = createComponent('navbar')
 export default create({
   props: {
     leftShow: { type: Boolean, default: true }, //左侧  是否显示返回icon
@@ -48,75 +65,91 @@ export default create({
     desc: { type: String, default: '' }, //右侧   按钮文字
     fixed: {
       type: Boolean,
-      default: false
+      default: false,
     },
     safeAreaInsetTop: {
       type: Boolean,
-      default: false
+      default: false,
     },
     border: {
       type: Boolean,
-      default: false
+      default: false,
     },
     placeholder: {
       // 生成一个等高的占位元素
       type: Boolean,
-      default: true
+      default: true,
     },
     zIndex: {
       type: [Number, String],
-      default: 10
-    }
+      default: 10,
+    },
+  },
+  computed: {
+    statusBarStyle() {
+      const style = {
+        height: '0px',
+        backgroundColor: '#fff',
+        width: '100%',
+        position: 'fixed',
+        top: 0,
+        zIndex: this.zIndex,
+      }
+      style.height = uni.getSystemInfoSync().statusBarHeight + 'px'
+      return style
+    },
   },
   emits: ['on-click-back', 'on-click-title', 'on-click-icon', 'on-click-right'],
-  mounted () {
+  mounted() {
     if (this.fixed && this.placeholder) {
-        setTimeout(async () => {
-          const query = uni.createSelectorQuery().in(this);
-          query
-            .select('.navBarHtml')
-            .boundingClientRect((rec: any) => {
-              this.navHeight = rec.height;
-              console.log('navBarHtml', this.navHeight);
-            })
-            .exec();
-        }, 100);
+      setTimeout(async () => {
+        const query = uni.createSelectorQuery().in(this)
+        query
+          .select('#navBarHtml')
+          .boundingClientRect((rec: any) => {
+            this.safeAreaInsetTop
+              ? (this.navHeight =
+                  rec.height + uni.getSystemInfoSync().statusBarHeight)
+              : (this.navHeight = rec.height)
+            console.log('navBarHtml', this.navHeight)
+          })
+          .exec()
+      }, 100)
     }
   },
   setup(props, { emit }) {
-    const { border, fixed, safeAreaInsetTop, placeholder, zIndex } = toRefs(props);
-    let navHeight = ref(0);
+    const { border, fixed, safeAreaInsetTop, placeholder, zIndex } =
+      toRefs(props)
+    let navHeight = ref(0)
     const classes = computed(() => {
-      const prefixCls = componentName;
+      const prefixCls = componentName
       return {
         [prefixCls]: true,
         [`${prefixCls}--border`]: border.value,
         [`${prefixCls}--fixed`]: fixed.value,
-        [`${prefixCls}--safe-area-inset-top`]: safeAreaInsetTop.value
-      };
-    });
+        // [`${prefixCls}--safe-area-inset-top`]: safeAreaInsetTop.value
+      }
+    })
 
     const styles = computed(() => {
       return {
-        zIndex: zIndex.value
-      };
-    });
-
-  
+        zIndex: zIndex.value,
+      }
+    })
 
     function handleLeft() {
-      emit('on-click-back');
+      emit('on-click-back')
     }
 
     function handleCenter() {
-      emit('on-click-title');
+      emit('on-click-title')
     }
     function handleCenterIcon() {
-      emit('on-click-icon');
+      emit('on-click-icon')
     }
 
     function handleRight() {
-      emit('on-click-right');
+      emit('on-click-right')
     }
 
     return {
@@ -126,12 +159,19 @@ export default create({
       handleLeft,
       handleCenter,
       handleCenterIcon,
-      handleRight
-    };
-  }
-});
+      handleRight,
+      safeAreaInsetTop,
+    }
+  },
+})
 </script>
 
 <style lang="scss" :scoped="false">
-@import './index.scss'
+@import './index.scss';
+.nut-navbar {
+  &--fixed {
+    top: v-bind('statusBarStyle.height');
+  }
+}
 </style>
+


### PR DESCRIPTION
fix: 
1.在H5和APP中，同时开启fixed和placeholder，获取不到组件高度，因为uniapp的selectorQuery.select(selector)不支持ref获取元素的方法。
2.在H5和APP中，在开启safe-area-inset-top后，顶部安全区高度获取异常，由于某些安卓和微信开发工具无法识别css的顶部状态栏变量，所以使用js获取的方式