### PR TITLE
fix: searchBar设置readonly后不生效的问题

### DIFF
--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/rate/template.html
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/rate/template.html
@@ -5,7 +5,7 @@
             :class="{ 'nut-rate-item__icon--disabled': disabled || n > modelValue }"
             :color="n <= modelValue ? activeColor : voidColor" :font-class-name="fontClassName"
             :class-prefix="classPrefix" :name="n <= modelValue ? checkedIcon : uncheckedIcon" />
-        <nut-icon v-if="allowHalf && Number(modelValue) + 1 > n" class="nut-rate-item__icon a nut-rate-item__icon--half"
+        <nut-icon v-if="allowHalf && Number(modelValue) + 1 > n" class="nut-rate-item__icon nut-rate-item__icon--half"
             @click="onClick(2, n)" :font-class-name="fontClassName" :class-prefix="classPrefix"
             :color="n <= Number(modelValue) + 1 ? activeColor : voidColor" :size="iconSize" :name="checkedIcon" />
         <nut-icon v-else-if="allowHalf && Number(modelValue) + 1 <= n"

--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/rate/template.html
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/rate/template.html
@@ -1,14 +1,14 @@
 <view :class="classes" @touchstart="onTouchStart" @touchmove="onTouchMove">
     <view class="nut-rate-item" v-for="n in Number(count)" :key="n" ref="rateRefs" :id="'rateRefs-' + refRandomId + n"
         :style="{ marginRight: pxCheck(spacing) }">
-        <nut-icon :size="iconSize" class="nut-rate-item__icon" @click="onClick(1, n)"
+        <nut-icon v-if="!allowHalf" :size="iconSize" class="nut-rate-item__icon" @click="onClick(1, n)"
             :class="{ 'nut-rate-item__icon--disabled': disabled || n > modelValue }"
             :color="n <= modelValue ? activeColor : voidColor" :font-class-name="fontClassName"
             :class-prefix="classPrefix" :name="n <= modelValue ? checkedIcon : uncheckedIcon" />
-        <nut-icon v-if="allowHalf && Number(modelValue) + 1 > n" class="nut-rate-item__icon nut-rate-item__icon--half"
+        <nut-icon v-if="allowHalf && Number(modelValue) + 1 > n" class="nut-rate-item__icon a nut-rate-item__icon--half"
             @click="onClick(2, n)" :font-class-name="fontClassName" :class-prefix="classPrefix"
             :color="n <= Number(modelValue) + 1 ? activeColor : voidColor" :size="iconSize" :name="checkedIcon" />
-        <nut-icon v-else-if="allowHalf && Number(modelValue) + 1 < n"
+        <nut-icon v-else-if="allowHalf && Number(modelValue) + 1 <= n"
             class="nut-rate-item__icon nut-rate-item__icon--disabled nut-rate-item__icon--half" @click="onClick(2, n)"
             :font-class-name="fontClassName" :class-prefix="classPrefix" :color="voidColor" :size="iconSize"
             :name="uncheckedIcon" />

--- a/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/searchbar/index.vue
+++ b/uni_modules/sky-nutui/components/sky-nutui/packages/__VUE/searchbar/index.vue
@@ -21,7 +21,7 @@
             :maxlength="maxLength"
             :placeholder="placeholder || translate('placeholder')"
             :value="modelValue"
-            :disabled="disabled"
+            :disabled="disabled || readonly"
             :readonly="readonly"
             @click="clickInput"
             @input="valueChange"
@@ -30,7 +30,7 @@
             :style="styleSearchbar"
           />
         </form>
-        <view @click="handleClear" class="nut-searchbar__input-clear" v-if="clearable&&modelValue.length > 0" >
+        <view @click="handleClear" class="nut-searchbar__input-clear" v-if="clearable&&modelValue.length > 0&&!disabled&&!readonly" >
           <nut-icon name="circle-close" size="12" color="#555"></nut-icon>
         </view>
       </view>


### PR DESCRIPTION
1. fix：Searchbar  readonly不生效的问题。 因uniapp的input无readonly属性，所以readonly合并到disabled中
2. fix：Searchbar设置readonly或disabled时不显示清除按钮
3. fix：半星显示双倍星星数量